### PR TITLE
🛡️ Sentinel: [HIGH] Pin third-party CSS versions and add Subresource Integrity (SRI)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,1 @@
+- 2025-03-07: [Supply Chain Risk] Unpinned third-party resources without Subresource Integrity (SRI) can allow malicious code execution or data exfiltration if the CDN is compromised.

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <title>Bookmarklet Theme</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0"> 
-    <link rel="stylesheet" hrefg="https://unpkg.com/sakura.css/css/sakura.css" id="theme">
+    <link rel="stylesheet" href="https://unpkg.com/sakura.css@1.5.1/css/sakura.css" integrity="sha384-ZKJPMh7X2VgE0MEjXdbOZxmKGF8C3UJvKmoP96SiJNPQLMN372XBrBK9m1cHvC4r" crossorigin="anonymous" id="theme">
     <style>
       a#link {
 	font-size: 2rem;

--- a/script.js
+++ b/script.js
@@ -26,11 +26,11 @@
 
     cssNode.id = "css";
     cssNode.rel = "stylesheet";
-    cssNode.href = "https://unpkg.com/sakura.css/css/sakura.css";
     cssNode.type = "text/css";
+    cssNode.crossOrigin = "anonymous";
     const themes = {
-        'white': "https://unpkg.com/sakura.css/css/sakura.css",
-        'dark': "https://unpkg.com/sakura.css/css/sakura-dark.css"
+        'white': { url: "https://unpkg.com/sakura.css@1.5.1/css/sakura.css", integrity: "sha384-ZKJPMh7X2VgE0MEjXdbOZxmKGF8C3UJvKmoP96SiJNPQLMN372XBrBK9m1cHvC4r" },
+        'dark': { url: "https://unpkg.com/sakura.css@1.5.1/css/sakura-dark.css", integrity: "sha384-WfWZ/vL5Qqc7KCYT4egNnDatzmhlcNoXn5MTzhOIijamONILzryKenMfUAwwtTpb" }
     }
     function getSelectedThemeName() {
         return localStorage.getItem(localstorageKey) || cssDefaultTheme
@@ -38,7 +38,11 @@
     function triggerThemeChange() {
         const theme = getSelectedThemeName()
         buttonThemeToggle.innerHTML = theme + "<sub> </sub>"
-        cssNode.href = themes[theme] || themes[cssDefaultTheme]
+        let selectedTheme = themes[theme];
+        if (!selectedTheme || typeof selectedTheme.url !== 'string') selectedTheme = themes[cssDefaultTheme];
+        if (!selectedTheme || typeof selectedTheme.url !== 'string') selectedTheme = themes['white'];
+        cssNode.href = selectedTheme.url;
+        cssNode.integrity = selectedTheme.integrity;
         const size = String(fontSizeRem)
         root.style.fontSize = `calc(16px + ${size}px)`
     }


### PR DESCRIPTION
Severity: HIGH
Vulnerability: Loading external unpinned third-party CSS resources without Subresource Integrity (SRI).
Impact: If the CDN is compromised, an attacker can substitute the CSS with malicious rules. CSS injection can be used for data exfiltration (via attribute selectors), potentially stealing passwords or modifying page contents without directly relying on XSS. Since the bookmarklet can be executed on sensitive websites, the impact is severe.
Fix: Pinned `sakura.css` from unpkg.com to version `1.5.1` to prevent unmanaged updates. Added `integrity` and `crossorigin` attributes to `index.html` and implemented dynamic hash switching in `script.js` whenever the theme changes to ensure all fetched CSS matches the expected SHA-384 hashes. Also fixed a minor typo `hrefg` -> `href`.
Verification: Created Playwright script to verify elements load with the correct SRI hashes locally, and ensured the application still successfully retrieves and applies the theme from unpkg without SRI errors.

Assumptions: The `@1.5.1` version of sakura.css is stable and no longer actively maintained. Optional chaining or `typeof` assertions were used to handle `themes[theme].url` properly instead of relying on potential user-controlled input falling over if an object is not present.
Alternatives Not Chosen: Did not rewrite `sakura.css` to be hosted locally/inline because it's simpler and follows the repository's current design to use a CDN.
How To Pivot: To remove SRI completely, revert the addition of the `.url` and `.integrity` properties in `script.js` and remove the attributes from `index.html`.
Next Knobs: We could consider generating SRI hashes during a build step if this repository ever implements one.

---
*PR created automatically by Jules for task [11356730867928589866](https://jules.google.com/task/11356730867928589866) started by @lucasew*