### PR TITLE
🛠️ Refactor: Extract Button Configuration and Centralize Error Reporting in script.js

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# Bookmarklet Theme Agent Guidelines
+
+## General Philosophy
+- Vanilla HTML/JS project: DO NOT introduce package managers (no `package.json`), build steps, or third-party frameworks.
+- Keep dependencies minimal, directly imported via CDN (e.g. `unpkg`).
+
+## Conventions
+- **Centralized Error Reporting:** All unexpected errors must be funneled through a centralized function (e.g. `reportError`). Every `catch` block MUST use it. Silent failures and direct `console.error` calls are prohibited.
+- **Rule of Three:** Do not prematurely abstract code until duplication occurs at least three times. When it does, refactoring to adhere to the Single Responsibility Principle is required.
+- **Security:** Ensure inputs are sanitized (especially URL parameters and user-controlled innerHTML) to prevent DOM-based XSS or arbitrary local storage poisoning. Reference `Sentinel` PRs.
+
+## Directory Layout
+- `/script.js` -> Main entrypoint and UI controller.
+- `/index.html` -> Bookmarklet anchor and test playground.

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,5 @@
+[tasks.ci]
+run = "node -c script.js"
+
+[tasks.test]
+run = "node -c script.js"

--- a/script.js
+++ b/script.js
@@ -1,88 +1,94 @@
 (function () {
-    const root = document.querySelector(':root')
-    const url = new URL(document.currentScript.src)
-    let cssTheme = url.searchParams.get('theme') || 'white'
-    const cssDefaultTheme = url.searchParams.get('defautTheme') || cssTheme
-    const cssDefaultDarkTheme = url.searchParams.get('defautDarkTheme') || 'dark'
-    const localstorageKey = url.searchParams.get('localstorageKey') || 'theme'
+    function reportError(error) {
+        console.error("[Bookmarklet Theme Error]", error);
+        // Could be wired to Sentry or another centralized logging service here
+    }
 
-    let fontSizeRem = parseInt(url.searchParams.get('fontsize')) || 1
+    try {
+        const root = document.querySelector(':root')
+        const url = new URL(document.currentScript.src)
+        let cssTheme = url.searchParams.get('theme') || 'white'
+        const cssDefaultTheme = url.searchParams.get('defautTheme') || cssTheme
+        const cssDefaultDarkTheme = url.searchParams.get('defautDarkTheme') || 'dark'
+        const localstorageKey = url.searchParams.get('localstorageKey') || 'theme'
 
-    const buttonThemeToggle = document.createElement('button')
-    const buttonArea = document.createElement('div')
-    let cssNode = null
-    if (!cssNode) {
-        const themeNode = document.getElementById('theme')
-        if (themeNode) {
-            if (themeNode.nodeName == "LINK" && themeNode.rel == "stylesheet") {
-                cssNode = themeNode
+        let fontSizeRem = parseInt(url.searchParams.get('fontsize')) || 1
+
+        const buttonArea = document.createElement('div')
+        let cssNode = null
+        if (!cssNode) {
+            const themeNode = document.getElementById('theme')
+            if (themeNode) {
+                if (themeNode.nodeName == "LINK" && themeNode.rel == "stylesheet") {
+                    cssNode = themeNode
+                }
             }
         }
-    }
-    if (!cssNode) {
-        cssNode = document.createElement('link');
-        document.head.appendChild(cssNode)
-    }
-
-    cssNode.id = "css";
-    cssNode.rel = "stylesheet";
-    cssNode.href = "https://unpkg.com/sakura.css/css/sakura.css";
-    cssNode.type = "text/css";
-    const themes = {
-        'white': "https://unpkg.com/sakura.css/css/sakura.css",
-        'dark': "https://unpkg.com/sakura.css/css/sakura-dark.css"
-    }
-    function getSelectedThemeName() {
-        return localStorage.getItem(localstorageKey) || cssDefaultTheme
-    }
-    function triggerThemeChange() {
-        const theme = getSelectedThemeName()
-        buttonThemeToggle.innerHTML = theme + "<sub> </sub>"
-        cssNode.href = themes[theme] || themes[cssDefaultTheme]
-        const size = String(fontSizeRem)
-        root.style.fontSize = `calc(16px + ${size}px)`
-    }
-    function changeFontSize(diff) {
-        fontSizeRem = fontSizeRem + diff
-        triggerThemeChange()
-    }
-    function toggleTheme() {
-        const selected = getSelectedThemeName()
-        if (selected === cssDefaultTheme) {
-            localStorage.setItem(localstorageKey, cssDefaultDarkTheme)
-        } else {
-            localStorage.setItem(localstorageKey, cssDefaultTheme)
+        if (!cssNode) {
+            cssNode = document.createElement('link');
+            document.head.appendChild(cssNode)
         }
-        triggerThemeChange()
+
+        cssNode.id = "css";
+        cssNode.rel = "stylesheet";
+        cssNode.href = "https://unpkg.com/sakura.css/css/sakura.css";
+        cssNode.type = "text/css";
+        const themes = {
+            'white': "https://unpkg.com/sakura.css/css/sakura.css",
+            'dark': "https://unpkg.com/sakura.css/css/sakura-dark.css"
+        }
+
+        function getSelectedThemeName() {
+            return localStorage.getItem(localstorageKey) || cssDefaultTheme
+        }
+        function triggerThemeChange() {
+            const theme = getSelectedThemeName()
+            buttonThemeToggle.innerHTML = theme + "<sub> </sub>"
+            cssNode.href = themes[theme] || themes[cssDefaultTheme]
+            const size = String(fontSizeRem)
+            root.style.fontSize = `calc(16px + ${size}px)`
+        }
+        function changeFontSize(diff) {
+            fontSizeRem = fontSizeRem + diff
+            triggerThemeChange()
+        }
+        function toggleTheme() {
+            const selected = getSelectedThemeName()
+            if (selected === cssDefaultTheme) {
+                localStorage.setItem(localstorageKey, cssDefaultDarkTheme)
+            } else {
+                localStorage.setItem(localstorageKey, cssDefaultTheme)
+            }
+            triggerThemeChange()
+        }
+
+        function createControlButton(innerHTML, onClick) {
+            const button = document.createElement('button')
+            button.onclick = onClick
+            button.innerHTML = innerHTML
+            button.style.height = "0.5in"
+            button.style.width = "calc(100vw / 3)"
+            button.style.padding = '0'
+            return button
+        }
+
+        const buttonIncreaseFont = createControlButton('A<sub>+</sub>', () => changeFontSize(1))
+        const buttonThemeToggle = createControlButton('', toggleTheme)
+        const buttonDecreaseFont = createControlButton('A<sub>-</sub>', () => changeFontSize(-1))
+
+        triggerThemeChange() // Requires buttonThemeToggle to be initialized so innerHTML can be updated
+
+        buttonArea.style.position = "fixed"
+        buttonArea.style.bottom = 0
+        buttonArea.style.left = 0
+        buttonArea.style.lineHeight = 0
+        buttonArea.style.fontSize = 0
+        buttonArea.style.width = "100vw"
+        buttonArea.appendChild(buttonIncreaseFont)
+        buttonArea.appendChild(buttonThemeToggle)
+        buttonArea.appendChild(buttonDecreaseFont)
+        document.body.appendChild(buttonArea)
+    } catch (error) {
+        reportError(error);
     }
-    triggerThemeChange()
-    buttonThemeToggle.onclick = toggleTheme
-    buttonThemeToggle.style.height = "0.5in"
-    buttonThemeToggle.style.width = "calc(100vw / 3)"
-    buttonThemeToggle.style.padding = '0'
-    
-    const buttonIncreaseFont = document.createElement('button')
-    buttonIncreaseFont.onclick = () => changeFontSize(1)
-    buttonIncreaseFont.innerHTML = 'A<sub>+</sub>'
-    buttonIncreaseFont.style.height = "0.5in"
-    buttonIncreaseFont.style.width = "calc(100vw / 3)"
-    buttonIncreaseFont.style.padding = '0'
-
-    const buttonDecreaseFont = document.createElement('button')
-    buttonDecreaseFont.onclick = () => changeFontSize(-1)
-    buttonDecreaseFont.innerHTML = 'A<sub>-</sub>'
-    buttonDecreaseFont.style.height = "0.5in"
-    buttonDecreaseFont.style.width = "calc(100vw / 3)"
-    buttonDecreaseFont.style.padding = '0'
-
-    buttonArea.style.position = "fixed"
-    buttonArea.style.bottom = 0
-    buttonArea.style.left = 0
-    buttonArea.style.lineHeight = 0
-    buttonArea.style.fontSize = 0
-    buttonArea.style.width = "100vw"
-    buttonArea.appendChild(buttonIncreaseFont)
-    buttonArea.appendChild(buttonThemeToggle)
-    buttonArea.appendChild(buttonDecreaseFont)
-    document.body.appendChild(buttonArea)
 })()


### PR DESCRIPTION
### Assumptions
- The variables `cssDefaultTheme` and `cssDefaultDarkTheme` parse `defautTheme` and `defautDarkTheme` from the URL params respectively. Though likely typos for "default", we assume they must remain unchanged for backward compatibility with external integrations or bookmarklets users currently have installed.
- No third-party UI framework or build tools are desired, so extraction logic adheres strictly to Vanilla JS DOM APIs.
- The `triggerThemeChange` function correctly hoists and captures the `buttonThemeToggle` state even before it has been formally appended to the DOM, and this behavior was intentional.

### Alternatives Not Chosen
- **Extracting a full Class (e.g. `ThemeController`):** While an option, it was deemed overkill for a single IIFE script currently operating with shared lexical scope closures. Extracting a `createControlButton` helper achieves the necessary DRY refactoring with a smaller footprint.
- **Introducing an external centralized logging framework (e.g. Sentry):** We implemented the centralized `reportError` function interface, but did not introduce an external script tag because the explicit logging service was not provided and dependencies are kept minimal.

### How To Pivot
- If you prefer a full Class extraction instead of just a function helper, remove `createControlButton` and wrap the entire `try` block logic in a `class BookmarkletThemeController { constructor() { ... } }` structure.

### Next Knobs
- The `AGENTS.md` file can be expanded to include strict naming conventions for query parameters.
- The `reportError` function body in `script.js` can be updated to include a `fetch` call to a central logging server.
- The `mise.toml` `test` target can be configured to run a Playwright or Puppeteer script instead of just `node -c` for more robust CI checks.

---
*PR created automatically by Jules for task [445797474098923556](https://jules.google.com/task/445797474098923556) started by @lucasew*